### PR TITLE
chore(config): regenerate ros2_control + controllers for unified mock-hardware path

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Common arguments:
 
 | Launch | Arg | Default | Notes |
 |--------|-----|---------|-------|
-| `control.launch.py` | `urdf_path`, `base_path`, `controllers_yaml`, `use_mock_hardware` | from `config/control.launch.yaml` | `use_mock_hardware:=true` swaps `LucySystemHardware` for `mock_components/GenericSystem`. |
+| `control.launch.py` | `urdf_path`, `base_path`, `controllers_yaml`, `use_mock_hardware` | from `config/control.launch.yaml` | `use_mock_hardware:=true` keeps `LucySystemHardware` but sets `publish_actuators:=false` so URDF clamping is enforced without micro-ROS publishing. |
 | `gazebo.launch.py` | `urdf_path`, `base_path`, `controllers_yaml`, `headless`, `start_rviz` | package share | `headless:=true` runs `gz sim -s -r --headless-rendering`. |
 | `rviz_standalone.launch.py` | `rviz_config`, `use_sim_time` | `config/inmoov_rviz.rviz`, `false` | Use when `/robot_description` + `/joint_states` already exist. |
 | `joint_preview.launch.py` | `jsp_gui` | `true` | `false` hides sliders so an external publisher can drive `/joint_states`. |
@@ -121,7 +121,7 @@ ros2 run xacro xacro description/urdf/inmoov.urdf.xacro \
 |----------|---------|---------|
 | `base_path` | `.` | Parent of `robot_description/`; the xacro appends `/robot_description/meshes/dae`. |
 | `use_gazebo_sim` | `false` | `true` enables `gz_ros2_control` plugin + Gazebo physics overrides. |
-| `use_mock_hardware` | `false` | `true` swaps the real-hardware plugin for `mock_components/GenericSystem`. |
+| `use_mock_hardware` | `false` | `true` keeps `LucySystemHardware` but disables the micro-ROS actuator publisher (URDF clamping still runs). |
 
 `model_scale` is **not** a launch arg — it is a single xacro property in [`description/robot_description/urdf/properties.xacro`](description/robot_description/urdf/properties.xacro) (current value `0.1196`, targets a measured crown height of 1.80 m). The flat URDF is **not** committed; regenerate on demand when needed.
 

--- a/config/controllers.yaml
+++ b/config/controllers.yaml
@@ -16,14 +16,6 @@ joint_state_broadcaster:
     extra_joints:
       - Empty.001_link_joint
       - Empty.002_link_joint
-      - i01.head.eyeLeft.001_link_joint
-      - i01.head.eyeLeft_link_joint
-      - i01.head.eyeRight.001_link_joint
-      - i01.head.eyeRight_link_joint
-      - i01.head.jaw_link_joint
-      - i01.head.neck.001_link_joint
-      - i01.head.rollNeck_link_joint
-      - i01.head.rothead_link_joint
       - i01.leftHand.index2_link_joint
       - i01.leftHand.index3_link_joint
       - i01.leftHand.majeure2_link_joint
@@ -50,8 +42,6 @@ joint_state_broadcaster:
       - i01.rightHand.thumb1_link_joint
       - i01.rightHand.thumb3_link_joint
       - i01.rightHand.wrist.001_link_joint
-      - i01.torso.midStom_link_joint
-      - i01.torso.topStom_link_joint
 
 left_arm_controller:
   ros__parameters:
@@ -95,6 +85,16 @@ torso_head_controller:
     joints:
       - left_shoulder_y_link_joint
       - right_shoulder_y_link_joint
+      - i01.torso.midStom_link_joint
+      - i01.torso.topStom_link_joint
+      - i01.head.rothead_link_joint
+      - i01.head.rollNeck_link_joint
+      - i01.head.neck.001_link_joint
+      - i01.head.jaw_link_joint
+      - i01.head.eyeRight_link_joint
+      - i01.head.eyeRight.001_link_joint
+      - i01.head.eyeLeft_link_joint
+      - i01.head.eyeLeft.001_link_joint
     command_interfaces:
       - position
     state_interfaces:

--- a/config/hardware/active.yaml
+++ b/config/hardware/active.yaml
@@ -3,20 +3,17 @@
 # left_shoulder_y_link_joint / right_shoulder_y_link_joint: torso board.
 
 version: 1
-robot_name: thais
+robot_name: inmoov
 
-passive_urdf_joints:
-  - i01.head.eyeLeft.001_link_joint
-  - i01.head.eyeLeft_link_joint
-  - i01.head.eyeRight.001_link_joint
-  - i01.head.eyeRight_link_joint
-  - i01.head.jaw_link_joint
-  - i01.head.neck.001_link_joint
-  - i01.head.rollNeck_link_joint
-  - i01.head.rothead_link_joint
-  - i01.torso.midStom_link_joint
-  - i01.torso.topStom_link_joint
+# Generated-artifact filenames (bare basenames; directories are fixed by repo
+# convention: description/ros2_control/ and config/). Consumed by
+# lucy_config_generator, lucy_config_pipeline, inmoov.urdf.xacro and the
+# thais_urdf launches so every layer agrees on the names.
+generated_files:
+  ros2_control_xacro: inmoov_ros2_control.xacro
+  controllers_yaml: controllers.yaml
 
+passive_urdf_joints: []
 ignore_urdf_joints:
   - Empty.001_link_joint
   - Empty.002_link_joint
@@ -46,14 +43,11 @@ ignore_urdf_joints:
   - i01.rightHand.thumb1_link_joint
   - i01.rightHand.thumb3_link_joint
   - i01.rightHand.wrist.001_link_joint
-
 firmware:
   source_dir: micro_ros_raspberrypi_pico_sdk
   build_dir: build
-
 controller_manager:
   update_rate: 100
-
 boards:
   rp2040_left_arm:
     serial_id: E6617C93E3858429
@@ -78,7 +72,7 @@ boards:
       name: right_arm_controller
       type: joint_trajectory_controller/JointTrajectoryController
   rp2040_torso_head:
-    serial_id: ""
+    serial_id: ''
     board_class: internal_servo_i2c_pwm
     internal_servo_slots: 16
     firmware_target: pico_micro_ros_torso
@@ -88,274 +82,397 @@ boards:
     controller:
       name: torso_head_controller
       type: joint_trajectory_controller/JointTrajectoryController
-
 actuators:
-  # Torso board — shoulder Y joints are wired here (legacy URDF names).
   - id: left_shoulder_y_torso
     urdf_joint: left_shoulder_y_link_joint
     board: rp2040_torso_head
     virtual_pin: 0
     physical_pin: 5
-    servo_type: "270"
-    offset_deg: 0.0
+    servo_type: '270'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 270.0
-    servo_default_deg: 0.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
   - id: right_shoulder_y_torso
     urdf_joint: right_shoulder_y_link_joint
     board: rp2040_torso_head
     virtual_pin: 1
     physical_pin: 6
-    servo_type: "270"
-    offset_deg: 0.0
+    servo_type: '270'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 270.0
-    servo_default_deg: 0.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
-
-  # Left arm (no shoulder Y — see torso entries above).
   - id: left_shoulder_z
     urdf_joint: left_shoulder_z_link_joint
     board: rp2040_left_arm
     virtual_pin: 0
     physical_pin: 10
-    servo_type: "270"
-    offset_deg: 0.0
+    servo_type: '270'
+    offset_deg: 90
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 270.0
-    servo_default_deg: 135.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
     enabled: false
   - id: left_shoulder_x
     urdf_joint: left_shoulder_x_link_joint
     board: rp2040_left_arm
     virtual_pin: 1
     physical_pin: 11
-    servo_type: "270"
-    offset_deg: 0.0
+    servo_type: '270'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 270.0
-    servo_default_deg: 135.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
   - id: left_elbow_x
     urdf_joint: left_elbow_x_link_joint
     board: rp2040_left_arm
     virtual_pin: 2
     physical_pin: 12
-    servo_type: "270"
-    offset_deg: 0.0
+    servo_type: '270'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 270.0
-    servo_default_deg: 90.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
   - id: left_wrist_z
     urdf_joint: left_wrist_z_link_joint
     board: rp2040_left_arm
     virtual_pin: 3
     physical_pin: 13
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 150
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 150.0
-    servo_default_deg: 50.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 300
+    servo_default_deg: 150
     enabled: false
   - id: left_thumb
     urdf_joint: i01.leftHand.thumb_link_joint
     board: rp2040_left_arm
     virtual_pin: 4
     physical_pin: 14
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 150.0
-    servo_default_deg: 50.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
   - id: left_index
     urdf_joint: i01.leftHand.index_link_joint
     board: rp2040_left_arm
     virtual_pin: 5
     physical_pin: 15
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 150.0
-    servo_default_deg: 50.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
   - id: left_majeure
     urdf_joint: i01.leftHand.majeure_link_joint
     board: rp2040_left_arm
     virtual_pin: 6
     physical_pin: 16
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 150.0
-    servo_default_deg: 50.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
   - id: left_ring
     urdf_joint: i01.leftHand.ringFinger_link_joint
     board: rp2040_left_arm
     virtual_pin: 7
     physical_pin: 17
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 150.0
-    servo_default_deg: 50.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
   - id: left_pinky
     urdf_joint: i01.leftHand.pinky_link_joint
     board: rp2040_left_arm
     virtual_pin: 8
     physical_pin: 18
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 150.0
-    servo_default_deg: 50.0
+    scale: 0.25
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
-
-  # Right arm
   - id: right_shoulder_z
     urdf_joint: right_shoulder_z_link_joint
     board: rp2040_right_arm
     virtual_pin: 0
     physical_pin: 10
-    servo_type: "270"
-    offset_deg: 0.0
-    direction: 1
-    scale: 1.0
-    servo_min_deg: 155.0
-    servo_max_deg: 165.0
-    servo_default_deg: 160.0
-    enabled: true
+    servo_type: '270'
+    offset_deg: 90
+    direction: -1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
   - id: right_shoulder_x
     urdf_joint: right_shoulder_x_link_joint
     board: rp2040_right_arm
     virtual_pin: 1
     physical_pin: 11
-    servo_type: "270"
-    offset_deg: 0.0
+    servo_type: '270'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 140.0
-    servo_max_deg: 180.0
-    servo_default_deg: 180.0
-    enabled: true
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
+    enabled: false
   - id: right_elbow_x
     urdf_joint: right_elbow_x_link_joint
     board: rp2040_right_arm
     virtual_pin: 2
     physical_pin: 12
-    servo_type: "270"
-    offset_deg: 0.0
+    servo_type: '270'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 100.0
-    servo_max_deg: 110.0
-    servo_default_deg: 100.0
-    enabled: true
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
+    enabled: false
   - id: right_wrist_z
     urdf_joint: right_wrist_z_link_joint
     board: rp2040_right_arm
     virtual_pin: 3
     physical_pin: 13
-    servo_type: "300"
-    offset_deg: 0.0
-    direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 230.0
-    servo_default_deg: 150.0
-    enabled: true
+    servo_type: '300'
+    offset_deg: 150
+    direction: -1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 300
+    servo_default_deg: 150
+    enabled: false
   - id: right_thumb
     urdf_joint: i01.rightHand.thumb_link_joint
     board: rp2040_right_arm
     virtual_pin: 4
     physical_pin: 14
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 36.0
-    servo_max_deg: 150.0
-    servo_default_deg: 36.0
-    enabled: true
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
+    enabled: false
   - id: right_index
     urdf_joint: i01.rightHand.index_link_joint
     board: rp2040_right_arm
     virtual_pin: 5
     physical_pin: 15
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 16.0
-    servo_max_deg: 150.0
-    servo_default_deg: 16.0
-    enabled: true
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
+    enabled: false
   - id: right_majeure
     urdf_joint: i01.rightHand.majeure_link_joint
     board: rp2040_right_arm
     virtual_pin: 6
     physical_pin: 16
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 21.0
-    servo_max_deg: 150.0
-    servo_default_deg: 21.0
-    enabled: true
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
+    enabled: false
   - id: right_ring
     urdf_joint: i01.rightHand.ringFinger_link_joint
     board: rp2040_right_arm
     virtual_pin: 7
     physical_pin: 17
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 33.0
-    servo_max_deg: 150.0
-    servo_default_deg: 33.0
-    enabled: true
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
+    enabled: false
   - id: right_pinky
     urdf_joint: i01.rightHand.pinky_link_joint
     board: rp2040_right_arm
     virtual_pin: 8
     physical_pin: 18
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 30.0
-    servo_max_deg: 150.0
-    servo_default_deg: 30.0
-    enabled: true
-
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
+    enabled: false
+  - id: act_left_arm_9
+    urdf_joint: i01.torso.midStom_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 2
+    physical_pin: 7
+    servo_type: '270'
+    offset_deg: 135
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 270
+    servo_default_deg: 135
+    enabled: false
+  - id: act_left_arm_10
+    urdf_joint: i01.torso.topStom_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 3
+    physical_pin: 8
+    servo_type: '270'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
+  - id: act_left_arm_11
+    urdf_joint: i01.head.rothead_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 4
+    physical_pin: 9
+    servo_type: '270'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
+  - id: act_left_arm_12
+    urdf_joint: i01.head.rollNeck_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 5
+    physical_pin: 10
+    servo_type: '270'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
+  - id: act_left_arm_13
+    urdf_joint: i01.head.neck.001_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 6
+    physical_pin: 11
+    servo_type: '300'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
+  - id: act_left_arm_14
+    urdf_joint: i01.head.jaw_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 7
+    physical_pin: 12
+    servo_type: '300'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
+  - id: act_left_arm_15
+    urdf_joint: i01.head.eyeRight_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 8
+    physical_pin: 13
+    servo_type: '180'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
+  - id: act_left_arm_16
+    urdf_joint: i01.head.eyeRight.001_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 9
+    physical_pin: 14
+    servo_type: '180'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
+  - id: act_left_arm_17
+    urdf_joint: i01.head.eyeLeft_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 10
+    physical_pin: 15
+    servo_type: '180'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
+  - id: act_right_arm_9
+    urdf_joint: i01.head.eyeLeft.001_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 11
+    physical_pin: 16
+    servo_type: '180'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
 sensors:
   - id: left_thumb_pressure
     type: pressure

--- a/config/hardware/active_meta.yaml
+++ b/config/hardware/active_meta.yaml
@@ -1,4 +1,4 @@
 name: "default"
-activated_at: "2026-05-16T12:21:12.013260Z"
+activated_at: "2026-06-04T22:07:59.688720Z"
 flashed_name: "thais_10_05_2026"
 flashed_at: "2026-05-10T21:27:59.896546Z"

--- a/config/hardware/configs/default.yaml
+++ b/config/hardware/configs/default.yaml
@@ -5,18 +5,15 @@
 version: 1
 robot_name: inmoov
 
-passive_urdf_joints:
-  - i01.head.eyeLeft.001_link_joint
-  - i01.head.eyeLeft_link_joint
-  - i01.head.eyeRight.001_link_joint
-  - i01.head.eyeRight_link_joint
-  - i01.head.jaw_link_joint
-  - i01.head.neck.001_link_joint
-  - i01.head.rollNeck_link_joint
-  - i01.head.rothead_link_joint
-  - i01.torso.midStom_link_joint
-  - i01.torso.topStom_link_joint
+# Generated-artifact filenames (bare basenames; directories are fixed by repo
+# convention: description/ros2_control/ and config/). Consumed by
+# lucy_config_generator, lucy_config_pipeline, inmoov.urdf.xacro and the
+# thais_urdf launches so every layer agrees on the names.
+generated_files:
+  ros2_control_xacro: inmoov_ros2_control.xacro
+  controllers_yaml: controllers.yaml
 
+passive_urdf_joints: []
 ignore_urdf_joints:
   - Empty.001_link_joint
   - Empty.002_link_joint
@@ -46,14 +43,11 @@ ignore_urdf_joints:
   - i01.rightHand.thumb1_link_joint
   - i01.rightHand.thumb3_link_joint
   - i01.rightHand.wrist.001_link_joint
-
 firmware:
   source_dir: micro_ros_raspberrypi_pico_sdk
   build_dir: build
-
 controller_manager:
   update_rate: 100
-
 boards:
   rp2040_left_arm:
     serial_id: E6617C93E3858429
@@ -78,7 +72,7 @@ boards:
       name: right_arm_controller
       type: joint_trajectory_controller/JointTrajectoryController
   rp2040_torso_head:
-    serial_id: ""
+    serial_id: ''
     board_class: internal_servo_i2c_pwm
     internal_servo_slots: 16
     firmware_target: pico_micro_ros_torso
@@ -88,274 +82,397 @@ boards:
     controller:
       name: torso_head_controller
       type: joint_trajectory_controller/JointTrajectoryController
-
 actuators:
-  # Torso board — shoulder Y joints are wired here (legacy URDF names).
   - id: left_shoulder_y_torso
     urdf_joint: left_shoulder_y_link_joint
     board: rp2040_torso_head
     virtual_pin: 0
     physical_pin: 5
-    servo_type: "270"
-    offset_deg: 0.0
+    servo_type: '270'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 270.0
-    servo_default_deg: 0.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
   - id: right_shoulder_y_torso
     urdf_joint: right_shoulder_y_link_joint
     board: rp2040_torso_head
     virtual_pin: 1
     physical_pin: 6
-    servo_type: "270"
-    offset_deg: 0.0
+    servo_type: '270'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 270.0
-    servo_default_deg: 0.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
-
-  # Left arm (no shoulder Y — see torso entries above).
   - id: left_shoulder_z
     urdf_joint: left_shoulder_z_link_joint
     board: rp2040_left_arm
     virtual_pin: 0
     physical_pin: 10
-    servo_type: "270"
-    offset_deg: 0.0
+    servo_type: '270'
+    offset_deg: 90
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 270.0
-    servo_default_deg: 135.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
     enabled: false
   - id: left_shoulder_x
     urdf_joint: left_shoulder_x_link_joint
     board: rp2040_left_arm
     virtual_pin: 1
     physical_pin: 11
-    servo_type: "270"
-    offset_deg: 0.0
+    servo_type: '270'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 270.0
-    servo_default_deg: 135.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
   - id: left_elbow_x
     urdf_joint: left_elbow_x_link_joint
     board: rp2040_left_arm
     virtual_pin: 2
     physical_pin: 12
-    servo_type: "270"
-    offset_deg: 0.0
+    servo_type: '270'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 270.0
-    servo_default_deg: 90.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
   - id: left_wrist_z
     urdf_joint: left_wrist_z_link_joint
     board: rp2040_left_arm
     virtual_pin: 3
     physical_pin: 13
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 150
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 150.0
-    servo_default_deg: 50.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 300
+    servo_default_deg: 150
     enabled: false
   - id: left_thumb
     urdf_joint: i01.leftHand.thumb_link_joint
     board: rp2040_left_arm
     virtual_pin: 4
     physical_pin: 14
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 150.0
-    servo_default_deg: 50.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
   - id: left_index
     urdf_joint: i01.leftHand.index_link_joint
     board: rp2040_left_arm
     virtual_pin: 5
     physical_pin: 15
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 150.0
-    servo_default_deg: 50.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
   - id: left_majeure
     urdf_joint: i01.leftHand.majeure_link_joint
     board: rp2040_left_arm
     virtual_pin: 6
     physical_pin: 16
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 150.0
-    servo_default_deg: 50.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
   - id: left_ring
     urdf_joint: i01.leftHand.ringFinger_link_joint
     board: rp2040_left_arm
     virtual_pin: 7
     physical_pin: 17
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 150.0
-    servo_default_deg: 50.0
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
   - id: left_pinky
     urdf_joint: i01.leftHand.pinky_link_joint
     board: rp2040_left_arm
     virtual_pin: 8
     physical_pin: 18
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 150.0
-    servo_default_deg: 50.0
+    scale: 0.25
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
     enabled: false
-
-  # Right arm
   - id: right_shoulder_z
     urdf_joint: right_shoulder_z_link_joint
     board: rp2040_right_arm
     virtual_pin: 0
     physical_pin: 10
-    servo_type: "270"
-    offset_deg: 0.0
-    direction: 1
-    scale: 1.0
-    servo_min_deg: 155.0
-    servo_max_deg: 165.0
-    servo_default_deg: 160.0
-    enabled: true
+    servo_type: '270'
+    offset_deg: 90
+    direction: -1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
   - id: right_shoulder_x
     urdf_joint: right_shoulder_x_link_joint
     board: rp2040_right_arm
     virtual_pin: 1
     physical_pin: 11
-    servo_type: "270"
-    offset_deg: 0.0
+    servo_type: '270'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 140.0
-    servo_max_deg: 180.0
-    servo_default_deg: 180.0
-    enabled: true
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
+    enabled: false
   - id: right_elbow_x
     urdf_joint: right_elbow_x_link_joint
     board: rp2040_right_arm
     virtual_pin: 2
     physical_pin: 12
-    servo_type: "270"
-    offset_deg: 0.0
+    servo_type: '270'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 100.0
-    servo_max_deg: 110.0
-    servo_default_deg: 100.0
-    enabled: true
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
+    enabled: false
   - id: right_wrist_z
     urdf_joint: right_wrist_z_link_joint
     board: rp2040_right_arm
     virtual_pin: 3
     physical_pin: 13
-    servo_type: "300"
-    offset_deg: 0.0
-    direction: 1
-    scale: 1.0
-    servo_min_deg: 0.0
-    servo_max_deg: 230.0
-    servo_default_deg: 150.0
-    enabled: true
+    servo_type: '300'
+    offset_deg: 150
+    direction: -1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 300
+    servo_default_deg: 150
+    enabled: false
   - id: right_thumb
     urdf_joint: i01.rightHand.thumb_link_joint
     board: rp2040_right_arm
     virtual_pin: 4
     physical_pin: 14
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 36.0
-    servo_max_deg: 150.0
-    servo_default_deg: 36.0
-    enabled: true
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
+    enabled: false
   - id: right_index
     urdf_joint: i01.rightHand.index_link_joint
     board: rp2040_right_arm
     virtual_pin: 5
     physical_pin: 15
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 16.0
-    servo_max_deg: 150.0
-    servo_default_deg: 16.0
-    enabled: true
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
+    enabled: false
   - id: right_majeure
     urdf_joint: i01.rightHand.majeure_link_joint
     board: rp2040_right_arm
     virtual_pin: 6
     physical_pin: 16
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 21.0
-    servo_max_deg: 150.0
-    servo_default_deg: 21.0
-    enabled: true
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
+    enabled: false
   - id: right_ring
     urdf_joint: i01.rightHand.ringFinger_link_joint
     board: rp2040_right_arm
     virtual_pin: 7
     physical_pin: 17
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 33.0
-    servo_max_deg: 150.0
-    servo_default_deg: 33.0
-    enabled: true
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
+    enabled: false
   - id: right_pinky
     urdf_joint: i01.rightHand.pinky_link_joint
     board: rp2040_right_arm
     virtual_pin: 8
     physical_pin: 18
-    servo_type: "300"
-    offset_deg: 0.0
+    servo_type: '300'
+    offset_deg: 0
     direction: 1
-    scale: 1.0
-    servo_min_deg: 30.0
-    servo_max_deg: 150.0
-    servo_default_deg: 30.0
-    enabled: true
-
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 0
+    enabled: false
+  - id: act_left_arm_9
+    urdf_joint: i01.torso.midStom_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 2
+    physical_pin: 7
+    servo_type: '270'
+    offset_deg: 135
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 270
+    servo_default_deg: 135
+    enabled: false
+  - id: act_left_arm_10
+    urdf_joint: i01.torso.topStom_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 3
+    physical_pin: 8
+    servo_type: '270'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
+  - id: act_left_arm_11
+    urdf_joint: i01.head.rothead_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 4
+    physical_pin: 9
+    servo_type: '270'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
+  - id: act_left_arm_12
+    urdf_joint: i01.head.rollNeck_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 5
+    physical_pin: 10
+    servo_type: '270'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
+  - id: act_left_arm_13
+    urdf_joint: i01.head.neck.001_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 6
+    physical_pin: 11
+    servo_type: '300'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
+  - id: act_left_arm_14
+    urdf_joint: i01.head.jaw_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 7
+    physical_pin: 12
+    servo_type: '300'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
+  - id: act_left_arm_15
+    urdf_joint: i01.head.eyeRight_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 8
+    physical_pin: 13
+    servo_type: '180'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
+  - id: act_left_arm_16
+    urdf_joint: i01.head.eyeRight.001_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 9
+    physical_pin: 14
+    servo_type: '180'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
+  - id: act_left_arm_17
+    urdf_joint: i01.head.eyeLeft_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 10
+    physical_pin: 15
+    servo_type: '180'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
+  - id: act_right_arm_9
+    urdf_joint: i01.head.eyeLeft.001_link_joint
+    board: rp2040_torso_head
+    virtual_pin: 11
+    physical_pin: 16
+    servo_type: '180'
+    offset_deg: 90
+    direction: 1
+    scale: 1
+    servo_min_deg: 0
+    servo_max_deg: 180
+    servo_default_deg: 90
+    enabled: false
 sensors:
   - id: left_thumb_pressure
     type: pressure

--- a/description/robot_description/urdf/robot_description.urdf.xacro
+++ b/description/robot_description/urdf/robot_description.urdf.xacro
@@ -366,7 +366,7 @@
     <axis xyz="-0.99994 0.00000 0.01111"/>
   </joint>
   <joint name="i01.head.rollNeck_link_joint" type="revolute">
-    <limit lower="0.00000" upper="0.00000" effort="100.00000" velocity="0.78540"/><!-- autocalibrated: 0.0 deg .. 0.0 deg (hit_lower=True, hit_upper=True) -->
+    <limit lower="-1.57080" upper="1.57080" effort="100.00000" velocity="0.78540"/><!-- hand-set: autocal sweep was degenerate (0 .. 0 deg) -->
     <dynamics damping="0.7" friction="0.5"/>
     <origin rpy="-0.00000 0.00000 -0.00000" xyz="${model_scale * 0.00000} ${model_scale * -0.00000} ${model_scale * 0.00435}"/>
     <parent link="i01.head.neck.001_link"/>

--- a/description/ros2_control/inmoov_ros2_control.xacro
+++ b/description/ros2_control/inmoov_ros2_control.xacro
@@ -10,11 +10,11 @@
             <plugin>gz_ros2_control/GazeboSimSystem</plugin>
           </xacro:if>
           <xacro:unless value="$(arg use_gazebo_sim)">
+            <plugin>lucy_ros2_control/LucySystemHardware</plugin>
             <xacro:if value="$(arg use_mock_hardware)">
-              <plugin>mock_components/GenericSystem</plugin>
+              <param name="publish_actuators">false</param>
             </xacro:if>
             <xacro:unless value="$(arg use_mock_hardware)">
-              <plugin>lucy_ros2_control/LucySystemHardware</plugin>
               <param name="publisher_topic">actuators/left_arm</param>
               <param name="node_name">lucy_hardware_interface_left_arm</param>
             </xacro:unless>
@@ -23,13 +23,16 @@
       <joint name="left_shoulder_z_link_joint">
           <param name="virtual_pin">0</param>
           <param name="servo_type">270</param>
-          <param name="offset_deg">0</param>
+          <param name="offset_deg">90</param>
           <param name="direction">1</param>
           <param name="scale">1</param>
           <param name="servo_min_deg">0</param>
-          <param name="servo_max_deg">270</param>
-          <param name="servo_default_deg">135</param>
-          <command_interface name="position" />
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">90</param>
+          <command_interface name="position">
+            <param name="min">-0.9163</param>
+            <param name="max">0.47124</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="left_shoulder_x_link_joint">
@@ -39,9 +42,12 @@
           <param name="direction">1</param>
           <param name="scale">1</param>
           <param name="servo_min_deg">0</param>
-          <param name="servo_max_deg">270</param>
-          <param name="servo_default_deg">135</param>
-          <command_interface name="position" />
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">0</param>
+          <command_interface name="position">
+            <param name="min">-1.5708</param>
+            <param name="max">2.35619</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="left_elbow_x_link_joint">
@@ -51,21 +57,27 @@
           <param name="direction">1</param>
           <param name="scale">1</param>
           <param name="servo_min_deg">0</param>
-          <param name="servo_max_deg">270</param>
-          <param name="servo_default_deg">90</param>
-          <command_interface name="position" />
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">0</param>
+          <command_interface name="position">
+            <param name="min">0.0</param>
+            <param name="max">1.5708</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="left_wrist_z_link_joint">
           <param name="virtual_pin">3</param>
           <param name="servo_type">300</param>
-          <param name="offset_deg">0</param>
+          <param name="offset_deg">150</param>
           <param name="direction">1</param>
           <param name="scale">1</param>
           <param name="servo_min_deg">0</param>
-          <param name="servo_max_deg">150</param>
-          <param name="servo_default_deg">50</param>
-          <command_interface name="position" />
+          <param name="servo_max_deg">300</param>
+          <param name="servo_default_deg">150</param>
+          <command_interface name="position">
+            <param name="min">-1.5708</param>
+            <param name="max">1.5708</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="i01.leftHand.thumb_link_joint">
@@ -75,9 +87,12 @@
           <param name="direction">1</param>
           <param name="scale">1</param>
           <param name="servo_min_deg">0</param>
-          <param name="servo_max_deg">150</param>
-          <param name="servo_default_deg">50</param>
-          <command_interface name="position" />
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">0</param>
+          <command_interface name="position">
+            <param name="min">0.0</param>
+            <param name="max">1.5708</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="i01.leftHand.index_link_joint">
@@ -87,9 +102,12 @@
           <param name="direction">1</param>
           <param name="scale">1</param>
           <param name="servo_min_deg">0</param>
-          <param name="servo_max_deg">150</param>
-          <param name="servo_default_deg">50</param>
-          <command_interface name="position" />
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">0</param>
+          <command_interface name="position">
+            <param name="min">0.0</param>
+            <param name="max">1.5708</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="i01.leftHand.majeure_link_joint">
@@ -99,9 +117,12 @@
           <param name="direction">1</param>
           <param name="scale">1</param>
           <param name="servo_min_deg">0</param>
-          <param name="servo_max_deg">150</param>
-          <param name="servo_default_deg">50</param>
-          <command_interface name="position" />
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">0</param>
+          <command_interface name="position">
+            <param name="min">0.0</param>
+            <param name="max">1.5708</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="i01.leftHand.ringFinger_link_joint">
@@ -111,9 +132,12 @@
           <param name="direction">1</param>
           <param name="scale">1</param>
           <param name="servo_min_deg">0</param>
-          <param name="servo_max_deg">150</param>
-          <param name="servo_default_deg">50</param>
-          <command_interface name="position" />
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">0</param>
+          <command_interface name="position">
+            <param name="min">0.0</param>
+            <param name="max">1.5708</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="i01.leftHand.pinky_link_joint">
@@ -121,11 +145,14 @@
           <param name="servo_type">300</param>
           <param name="offset_deg">0</param>
           <param name="direction">1</param>
-          <param name="scale">1</param>
+          <param name="scale">0.25</param>
           <param name="servo_min_deg">0</param>
-          <param name="servo_max_deg">150</param>
-          <param name="servo_default_deg">50</param>
-          <command_interface name="position" />
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">0</param>
+          <command_interface name="position">
+            <param name="min">0.0</param>
+            <param name="max">1.5708</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
   </ros2_control>
@@ -135,11 +162,11 @@
             <plugin>gz_ros2_control/GazeboSimSystem</plugin>
           </xacro:if>
           <xacro:unless value="$(arg use_gazebo_sim)">
+            <plugin>lucy_ros2_control/LucySystemHardware</plugin>
             <xacro:if value="$(arg use_mock_hardware)">
-              <plugin>mock_components/GenericSystem</plugin>
+              <param name="publish_actuators">false</param>
             </xacro:if>
             <xacro:unless value="$(arg use_mock_hardware)">
-              <plugin>lucy_ros2_control/LucySystemHardware</plugin>
               <param name="publisher_topic">actuators/right_arm</param>
               <param name="node_name">lucy_hardware_interface_right_arm</param>
             </xacro:unless>
@@ -148,13 +175,16 @@
       <joint name="right_shoulder_z_link_joint">
           <param name="virtual_pin">0</param>
           <param name="servo_type">270</param>
-          <param name="offset_deg">0</param>
-          <param name="direction">1</param>
+          <param name="offset_deg">90</param>
+          <param name="direction">-1</param>
           <param name="scale">1</param>
-          <param name="servo_min_deg">155</param>
-          <param name="servo_max_deg">165</param>
-          <param name="servo_default_deg">160</param>
-          <command_interface name="position" />
+          <param name="servo_min_deg">0</param>
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">90</param>
+          <command_interface name="position">
+            <param name="min">-0.42761</param>
+            <param name="max">0.83776</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="right_shoulder_x_link_joint">
@@ -163,10 +193,13 @@
           <param name="offset_deg">0</param>
           <param name="direction">1</param>
           <param name="scale">1</param>
-          <param name="servo_min_deg">140</param>
+          <param name="servo_min_deg">0</param>
           <param name="servo_max_deg">180</param>
-          <param name="servo_default_deg">180</param>
-          <command_interface name="position" />
+          <param name="servo_default_deg">0</param>
+          <command_interface name="position">
+            <param name="min">-1.5708</param>
+            <param name="max">2.35619</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="right_elbow_x_link_joint">
@@ -175,22 +208,28 @@
           <param name="offset_deg">0</param>
           <param name="direction">1</param>
           <param name="scale">1</param>
-          <param name="servo_min_deg">100</param>
-          <param name="servo_max_deg">110</param>
-          <param name="servo_default_deg">100</param>
-          <command_interface name="position" />
+          <param name="servo_min_deg">0</param>
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">0</param>
+          <command_interface name="position">
+            <param name="min">0.0</param>
+            <param name="max">1.5708</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="right_wrist_z_link_joint">
           <param name="virtual_pin">3</param>
           <param name="servo_type">300</param>
-          <param name="offset_deg">0</param>
-          <param name="direction">1</param>
+          <param name="offset_deg">150</param>
+          <param name="direction">-1</param>
           <param name="scale">1</param>
           <param name="servo_min_deg">0</param>
-          <param name="servo_max_deg">230</param>
+          <param name="servo_max_deg">300</param>
           <param name="servo_default_deg">150</param>
-          <command_interface name="position" />
+          <command_interface name="position">
+            <param name="min">-1.5708</param>
+            <param name="max">1.5708</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="i01.rightHand.thumb_link_joint">
@@ -199,10 +238,13 @@
           <param name="offset_deg">0</param>
           <param name="direction">1</param>
           <param name="scale">1</param>
-          <param name="servo_min_deg">36</param>
-          <param name="servo_max_deg">150</param>
-          <param name="servo_default_deg">36</param>
-          <command_interface name="position" />
+          <param name="servo_min_deg">0</param>
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">0</param>
+          <command_interface name="position">
+            <param name="min">0.0</param>
+            <param name="max">1.5708</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="i01.rightHand.index_link_joint">
@@ -211,10 +253,13 @@
           <param name="offset_deg">0</param>
           <param name="direction">1</param>
           <param name="scale">1</param>
-          <param name="servo_min_deg">16</param>
-          <param name="servo_max_deg">150</param>
-          <param name="servo_default_deg">16</param>
-          <command_interface name="position" />
+          <param name="servo_min_deg">0</param>
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">0</param>
+          <command_interface name="position">
+            <param name="min">0.0</param>
+            <param name="max">1.5708</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="i01.rightHand.majeure_link_joint">
@@ -223,10 +268,13 @@
           <param name="offset_deg">0</param>
           <param name="direction">1</param>
           <param name="scale">1</param>
-          <param name="servo_min_deg">21</param>
-          <param name="servo_max_deg">150</param>
-          <param name="servo_default_deg">21</param>
-          <command_interface name="position" />
+          <param name="servo_min_deg">0</param>
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">0</param>
+          <command_interface name="position">
+            <param name="min">0.0</param>
+            <param name="max">1.5708</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="i01.rightHand.ringFinger_link_joint">
@@ -235,10 +283,13 @@
           <param name="offset_deg">0</param>
           <param name="direction">1</param>
           <param name="scale">1</param>
-          <param name="servo_min_deg">33</param>
-          <param name="servo_max_deg">150</param>
-          <param name="servo_default_deg">33</param>
-          <command_interface name="position" />
+          <param name="servo_min_deg">0</param>
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">0</param>
+          <command_interface name="position">
+            <param name="min">0.0</param>
+            <param name="max">1.5708</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="i01.rightHand.pinky_link_joint">
@@ -247,10 +298,13 @@
           <param name="offset_deg">0</param>
           <param name="direction">1</param>
           <param name="scale">1</param>
-          <param name="servo_min_deg">30</param>
-          <param name="servo_max_deg">150</param>
-          <param name="servo_default_deg">30</param>
-          <command_interface name="position" />
+          <param name="servo_min_deg">0</param>
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">0</param>
+          <command_interface name="position">
+            <param name="min">0.0</param>
+            <param name="max">1.5708</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
   </ros2_control>
@@ -260,11 +314,11 @@
             <plugin>gz_ros2_control/GazeboSimSystem</plugin>
           </xacro:if>
           <xacro:unless value="$(arg use_gazebo_sim)">
+            <plugin>lucy_ros2_control/LucySystemHardware</plugin>
             <xacro:if value="$(arg use_mock_hardware)">
-              <plugin>mock_components/GenericSystem</plugin>
+              <param name="publish_actuators">false</param>
             </xacro:if>
             <xacro:unless value="$(arg use_mock_hardware)">
-              <plugin>lucy_ros2_control/LucySystemHardware</plugin>
               <param name="publisher_topic">actuators/torso</param>
               <param name="node_name">lucy_hardware_interface_torso_head</param>
             </xacro:unless>
@@ -277,9 +331,12 @@
           <param name="direction">1</param>
           <param name="scale">1</param>
           <param name="servo_min_deg">0</param>
-          <param name="servo_max_deg">270</param>
+          <param name="servo_max_deg">180</param>
           <param name="servo_default_deg">0</param>
-          <command_interface name="position" />
+          <command_interface name="position">
+            <param name="min">0.0</param>
+            <param name="max">1.5708</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="right_shoulder_y_link_joint">
@@ -289,13 +346,106 @@
           <param name="direction">1</param>
           <param name="scale">1</param>
           <param name="servo_min_deg">0</param>
-          <param name="servo_max_deg">270</param>
+          <param name="servo_max_deg">180</param>
           <param name="servo_default_deg">0</param>
-          <command_interface name="position" />
+          <command_interface name="position">
+            <param name="min">0.0</param>
+            <param name="max">1.5708</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
       <joint name="i01.torso.midStom_link_joint">
           <param name="virtual_pin">2</param>
+          <param name="servo_type">270</param>
+          <param name="offset_deg">135</param>
+          <param name="direction">1</param>
+          <param name="scale">1</param>
+          <param name="servo_min_deg">0</param>
+          <param name="servo_max_deg">270</param>
+          <param name="servo_default_deg">135</param>
+          <command_interface name="position">
+            <param name="min">-0.50615</param>
+            <param name="max">0.50615</param>
+          </command_interface>
+          <state_interface name="position" />
+      </joint>
+      <joint name="i01.torso.topStom_link_joint">
+          <param name="virtual_pin">3</param>
+          <param name="servo_type">270</param>
+          <param name="offset_deg">90</param>
+          <param name="direction">1</param>
+          <param name="scale">1</param>
+          <param name="servo_min_deg">0</param>
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">90</param>
+          <command_interface name="position">
+            <param name="min">-0.12217</param>
+            <param name="max">0.12217</param>
+          </command_interface>
+          <state_interface name="position" />
+      </joint>
+      <joint name="i01.head.rothead_link_joint">
+          <param name="virtual_pin">4</param>
+          <param name="servo_type">270</param>
+          <param name="offset_deg">90</param>
+          <param name="direction">1</param>
+          <param name="scale">1</param>
+          <param name="servo_min_deg">0</param>
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">90</param>
+          <command_interface name="position">
+            <param name="min">-0.08727</param>
+            <param name="max">0.04363</param>
+          </command_interface>
+          <state_interface name="position" />
+      </joint>
+      <joint name="i01.head.rollNeck_link_joint">
+          <param name="virtual_pin">5</param>
+          <param name="servo_type">270</param>
+          <param name="offset_deg">90</param>
+          <param name="direction">1</param>
+          <param name="scale">1</param>
+          <param name="servo_min_deg">0</param>
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">90</param>
+          <command_interface name="position">
+            <param name="min">-1.5708</param>
+            <param name="max">1.5708</param>
+          </command_interface>
+          <state_interface name="position" />
+      </joint>
+      <joint name="i01.head.neck.001_link_joint">
+          <param name="virtual_pin">6</param>
+          <param name="servo_type">300</param>
+          <param name="offset_deg">90</param>
+          <param name="direction">1</param>
+          <param name="scale">1</param>
+          <param name="servo_min_deg">0</param>
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">90</param>
+          <command_interface name="position">
+            <param name="min">-0.34907</param>
+            <param name="max">0.0</param>
+          </command_interface>
+          <state_interface name="position" />
+      </joint>
+      <joint name="i01.head.jaw_link_joint">
+          <param name="virtual_pin">7</param>
+          <param name="servo_type">300</param>
+          <param name="offset_deg">90</param>
+          <param name="direction">1</param>
+          <param name="scale">1</param>
+          <param name="servo_min_deg">0</param>
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">90</param>
+          <command_interface name="position">
+            <param name="min">0.0</param>
+            <param name="max">0.17453</param>
+          </command_interface>
+          <state_interface name="position" />
+      </joint>
+      <joint name="i01.head.eyeRight_link_joint">
+          <param name="virtual_pin">8</param>
           <param name="servo_type">180</param>
           <param name="offset_deg">90</param>
           <param name="direction">1</param>
@@ -303,19 +453,55 @@
           <param name="servo_min_deg">0</param>
           <param name="servo_max_deg">180</param>
           <param name="servo_default_deg">90</param>
-          <command_interface name="position" />
+          <command_interface name="position">
+            <param name="min">-0.7853</param>
+            <param name="max">0.7853</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
-      <joint name="i01.torso.topStom_link_joint">
-          <param name="virtual_pin">3</param>
+      <joint name="i01.head.eyeRight.001_link_joint">
+          <param name="virtual_pin">9</param>
           <param name="servo_type">180</param>
-          <param name="offset_deg">0</param>
+          <param name="offset_deg">90</param>
           <param name="direction">1</param>
           <param name="scale">1</param>
           <param name="servo_min_deg">0</param>
           <param name="servo_max_deg">180</param>
           <param name="servo_default_deg">90</param>
-          <command_interface name="position" />
+          <command_interface name="position">
+            <param name="min">-0.34907</param>
+            <param name="max">0.34907</param>
+          </command_interface>
+          <state_interface name="position" />
+      </joint>
+      <joint name="i01.head.eyeLeft_link_joint">
+          <param name="virtual_pin">10</param>
+          <param name="servo_type">180</param>
+          <param name="offset_deg">90</param>
+          <param name="direction">1</param>
+          <param name="scale">1</param>
+          <param name="servo_min_deg">0</param>
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">90</param>
+          <command_interface name="position">
+            <param name="min">-0.7853</param>
+            <param name="max">0.7853</param>
+          </command_interface>
+          <state_interface name="position" />
+      </joint>
+      <joint name="i01.head.eyeLeft.001_link_joint">
+          <param name="virtual_pin">11</param>
+          <param name="servo_type">180</param>
+          <param name="offset_deg">90</param>
+          <param name="direction">1</param>
+          <param name="scale">1</param>
+          <param name="servo_min_deg">0</param>
+          <param name="servo_max_deg">180</param>
+          <param name="servo_default_deg">90</param>
+          <command_interface name="position">
+            <param name="min">-0.34907</param>
+            <param name="max">0.34907</param>
+          </command_interface>
           <state_interface name="position" />
       </joint>
   </ros2_control>

--- a/description/urdf/inmoov.urdf.xacro
+++ b/description/urdf/inmoov.urdf.xacro
@@ -5,6 +5,9 @@
   <xacro:arg name="use_gazebo_sim" default="false"/>
   <xacro:arg name="use_mock_hardware" default="false"/>
   <xacro:arg name="controller_config" default=""/>
+  <!-- Generated ros2_control xacro basename (see generated_files in the hardware
+       mapping YAML). Directory is fixed at ../ros2_control/. -->
+  <xacro:arg name="ros2_control_file" default="inmoov_ros2_control.xacro"/>
   <xacro:property name="mesh_dir" value="file://$(arg base_path)/robot_description/meshes/dae"/>
   <xacro:property name="use_gazebo_sim" value="$(arg use_gazebo_sim)"/>
 
@@ -14,8 +17,9 @@
   <!-- Import inmoov physical description (urdf) macro (uses use_gazebo_sim for heavy stand in sim) -->
   <xacro:include filename="../robot_description/urdf/robot_description.urdf.xacro"/>
 
-  <!-- Import inmoov ros2_control description (use_gazebo_sim switches to gz_ros2_control in Gazebo launch) -->
-  <xacro:include filename="../ros2_control/inmoov_ros2_control.xacro" />
+  <!-- Import inmoov ros2_control description (use_gazebo_sim switches to gz_ros2_control in Gazebo launch).
+       Filename comes from the generated_files config so the generator, pipeline and launches agree. -->
+  <xacro:include filename="../ros2_control/$(arg ros2_control_file)" />
 
   <!-- Gazebo-only bits, gated on use_gazebo_sim:=true:
          - gazebo/inmoov_gazebo_physics.xacro    physics + surface tuning

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -99,7 +99,7 @@ Common arguments are listed in the root [README.md](../README.md#quick-launches)
 | `robot_description/urdf/properties.xacro` | `model_scale` xacro property — the **single** length-scale knob. Multiplies every joint/visual/collision `<origin xyz>` and primitive size in the body URDF. |
 | `robot_description/urdf/robot_description.urdf.xacro` | Links, joints, visuals (`<mesh>`), collisions (`<mesh>` or primitive), inertias, named `<material>` definitions, and `<material name="…"/>` refs on visuals. |
 | `robot_description/meshes/dae/*.dae` | Collada meshes — used by **all three renderers** as the visual mesh (Gazebo also as the source of `<diffuse>` colour for mesh visuals, see §6). |
-| `ros2_control/inmoov_ros2_control.xacro` | `<ros2_control>` block: selects `LucySystemHardware` (real), `gz_ros2_control/GazeboSimSystem` (Gazebo), or `mock_components/GenericSystem` (mock). |
+| `ros2_control/inmoov_ros2_control.xacro` | `<ros2_control>` block: selects `gz_ros2_control/GazeboSimSystem` (Gazebo) or `lucy_ros2_control/LucySystemHardware` (real + mock — `publish_actuators:=false` toggles the micro-ROS publisher off in mock). Each `<command_interface name="position">` carries `<param name="min/max">` from the URDF `<limit>`; `LucySystemHardware` clamps to that envelope. The stock `gz_ros2_control` plugin in this workspace does **not** apply the clamp. |
 | `ros2_control/inmoov_gz_ros2_control.xacro` | gz-sim only — declares the `gz_ros2_control-system` plugin so `controller_manager` runs inside Gazebo with `$(arg controller_config)`. |
 | `gazebo/inmoov_gazebo_physics.xacro` | gz-sim only — `<static>` on the stand, body/hand friction (`mu1/mu2`), contact stiffness (`kp/kd`), `self_collide` flags. **No colours** (see §6). |
 
@@ -150,6 +150,8 @@ Practical consequences:
 ### 6.5 Joint limits
 
 Limits are per-joint, in radians, on the `<limit lower="…" upper="…"/>` of each actuated joint in `robot_description.urdf.xacro`. They are **decoupled** from `config/hardware/active.yaml`: the hardware mapping handles servo↔URDF conversion (`offset_deg`, `direction`, `scale` — see [hardware_mapping.md](hardware_mapping.md)).
+
+`lucy_config_generator` copies the `<limit lower upper>` of every actuated joint into the `<command_interface name="position">` block of the regenerated `inmoov_ros2_control.xacro` as `<param name="min/max"/>` (radians). At runtime, `LucySystemHardware` clamps `hw_commands_` to that envelope before the actuator mapping. Stock `gz_ros2_control` does **not** apply this clamp; rely on URDF `<limit>` enforcement coming from the spawned model when running in Gazebo.
 
 Two complementary routes — see §7.
 
@@ -232,7 +234,7 @@ Treat the result as an **upper bound on the kinematic envelope**, not the real e
 After hand or auto-calibration, validate in the full stack:
 
 ```bash
-# Mock-hardware path (controllers spawn against GenericSystem; no Gazebo, no real motors)
+# Mock-hardware path (LucySystemHardware with publish_actuators:=false; no Gazebo, no real motors)
 ros2 launch lucy_bringup lucy.launch.py real:=false rviz:=true
 
 # Headless Gazebo (server-only with EGL rendering — camera sensors keep producing frames)

--- a/docs/hardware_mapping.md
+++ b/docs/hardware_mapping.md
@@ -27,17 +27,33 @@ For **InMoov i1 vs i2** scope and how to extend the YAML with **head / expressio
 
 ## Hardware angle limits (`servo_*_deg`)
 
-Values sent to real servos are expressed in **degrees in the servo’s own range**. This is independent of how the URDF might visualize the joint (often symmetric angles); the mapping from **URDF / ros2_control command** to **hardware command** is what `offset_deg`, `direction`, and `scale` are for (see below).
+`servo_min_deg`, `servo_max_deg`, and `servo_default_deg` are **servo-frame degrees**: the angle the motor actually sees, before any URDF visualization convention. They bound electrical/mechanical travel in firmware and in **LucySystemHardware** after the URDF→servo mapping.
 
-## `offset_deg`, `direction`, and `scale` (URDF command → hardware)
+They are **not** the same as the LCP slider’s joint-space meaning unless `offset_deg = 0`, `direction = ±1`, and `scale = 1`. The control panel slider is labeled in **servo degrees**; trajectory commands on the wire stay in **URDF radians**.
 
-These fields tune how a **trajectory command in joint space** (what `joint_trajectory_controller` and the URDF use for that `urdf_joint`) is converted to the **angle actually sent to the servo** (within `[servo_min_deg, servo_max_deg]`):
+## URDF `<limit>` (joint-space envelope)
 
-- **`direction`**: `+1` or `-1` to flip motion if the horn is mounted opposite to the positive URDF axis.
-- **`scale`**: ratio between a change in **commanded joint angle** and a change in **servo angle** when the mechanism is not 1:1 (gear reduction, non-linear linkage approximated as linear, etc.).
-- **`offset_deg`**: constant shift after direction/scale so that “zero” in the controller matches the real neutral pose for that hardware assembly.
+Each `urdf_joint` has `<limit lower="…" upper="…"/>` in the URDF (radians). **`lucy_config_generator`** copies those onto each actuated joint’s ros2_control position **command_interface** as `<param name="min">` / `<param name="max">` in `description/ros2_control/inmoov_ros2_control.xacro`. **LucySystemHardware** (real hardware and RViz/mock) clamps `hw_commands_` to that envelope before converting to actuator degrees, so MoveIt, teleop, CLI, and the LCP can command past the URDF wall in the UI but the stack stops at the realized angle. `/joint_states` reports the clamped joint position.
 
-So they are **calibration between ros2_control / URDF joint values and real actuator commands**, not a separate “RViz-only” layer. Gazebo (ideal model) may ignore them unless the sim stack is extended to mimic the same mapping; the **LucySystemHardware** plugin and firmware are the consumers of these parameters once generated into ros2_control.
+**Gazebo** uses stock **`gz_ros2_control/GazeboSimSystem`**, which does **not** apply those `min`/`max` params in `write()` — only **LucySystemHardware** enforces the ros2_control URDF envelope today. Gazebo may still respect joint limits from the spawned model/physics depending on how the world is built; that is separate from ros2_control clamping. After changing generated limits for real/mock, reload the control stack; for Gazebo topology changes, **restart Gazebo** so `gz_ros2_control` reloads the URDF.
+
+RViz-only / mock hardware uses **`lucy_ros2_control/LucySystemHardware`** with `publish_actuators:=false` so URDF limits are enforced the same way as on real hardware, without micro-ROS topics.
+
+## `offset_deg`, `direction`, and `scale` (URDF command ↔ servo)
+
+Symmetric mapping (used by **LucySystemHardware**, firmware, and the LCP):
+
+```text
+joint_deg = (servo_deg - offset_deg) * direction * scale
+servo_deg = joint_deg / (direction * scale) + offset_deg
+joint_rad = deg_to_rad(joint_deg)
+```
+
+- **`direction`**: `+1` or `-1` if the horn is mounted opposite the positive URDF axis.
+- **`scale`**: ratio between a change in **commanded joint angle** and **servo angle** when the linkage is not 1:1.
+- **`offset_deg`**: shift so URDF “zero” matches the real neutral assembly (e.g. `offset_deg: 90` with a 0–180° servo maps URDF 0° to servo 90°).
+
+These are **calibration between ros2_control / URDF joint commands and the servo command**, not an RViz-only layer. Generated ros2_control params are the source of truth for the plugin and for the panel’s publish/subscribe conversion.
 
 ## Shoulder Y joints
 
@@ -53,7 +69,7 @@ Extra head DOFs (eyelids, cheeks, separate eyeball drivers, and so on) are **not
 
 With **SIMULATION ONLY** enabled in the activate workflow, `lucy_config_generator` emits:
 
-- One `<ros2_control name="LucyHardwareSim">` block (`mock_components/GenericSystem` for RViz-only, `gz_ros2_control/GazeboSimSystem` when `use_gazebo_sim:=true`).
+- One `<ros2_control>` block per board (`gz_ros2_control/GazeboSimSystem` when `use_gazebo_sim:=true`, otherwise `lucy_ros2_control/LucySystemHardware` with `publish_actuators:=false` for RViz/mock). URDF `min`/`max` on the command interface are enforced by **LucySystemHardware** only (real + mock), not by the stock Gazebo plugin.
 - `controllers.yaml` with `joint_state_broadcaster` + a single `lucy_sim_controller` listing every actuator `urdf_joint`.
 
 After generation, `lucy_config_pipeline` calls **`/lucy_control/restart`** so the running stack reloads without a full `lucy.launch.py` restart. Structural joint changes still require that restart (Humble does not hot-swap URDF hardware topology).

--- a/launch/control.launch.py
+++ b/launch/control.launch.py
@@ -26,6 +26,12 @@ from launch.substitutions import LaunchConfiguration
 import yaml
 
 
+_DEFAULT_GENERATED_FILES = {
+    "ros2_control_xacro": "inmoov_ros2_control.xacro",
+    "controllers_yaml": "controllers.yaml",
+}
+
+
 def _load_launch_defaults(package_root: Path) -> dict[str, str]:
     config_path = package_root / "config" / "control.launch.yaml"
     data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
@@ -38,11 +44,29 @@ def _load_launch_defaults(package_root: Path) -> dict[str, str]:
     return {key: str(data[key]).strip() for key in required}
 
 
+def _active_generated_files(package_root: Path) -> dict[str, str]:
+    """Generated-artifact filenames from the active preset (defaults if unreadable)."""
+    active = package_root / "config" / "hardware" / "active.yaml"
+    out = dict(_DEFAULT_GENERATED_FILES)
+    try:
+        data = yaml.safe_load(active.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return out
+    section = data.get("generated_files") if isinstance(data, dict) else None
+    if isinstance(section, dict):
+        for key in out:
+            value = section.get(key)
+            if isinstance(value, str) and value.strip() and "/" not in value:
+                out[key] = value.strip()
+    return out
+
+
 def generate_launch_description():
     package_root = Path(__file__).resolve().parents[1]
     defaults = _load_launch_defaults(package_root)
+    generated = _active_generated_files(package_root)
     default_controllers_yaml = str(
-        (package_root / defaults["controllers_yaml"]).resolve()
+        (package_root / "config" / generated["controllers_yaml"]).resolve()
     )
     default_urdf = str((package_root / defaults["urdf_path"]).resolve())
     default_base = str((package_root / defaults["base_path"]).resolve())
@@ -72,7 +96,15 @@ def generate_launch_description():
     use_mock_hardware_arg = DeclareLaunchArgument(
         "use_mock_hardware",
         default_value="false",
-        description="Forwarded to xacro: emit mock_components/GenericSystem plugin",
+        description=(
+            "Forwarded to xacro: LucySystemHardware with publish_actuators:=false "
+            "(URDF clamping still applied, no micro-ROS publish)"
+        ),
+    )
+    ros2_control_file_arg = DeclareLaunchArgument(
+        "ros2_control_file",
+        default_value=generated["ros2_control_xacro"],
+        description="Generated ros2_control xacro basename (generated_files in active.yaml)",
     )
 
     supervisor_launch = TimerAction(
@@ -90,6 +122,7 @@ def generate_launch_description():
                     "use_mock_hardware": LaunchConfiguration("use_mock_hardware"),
                     "gazebo_only": "false",
                     "autostart": "true",
+                    "ros2_control_file": LaunchConfiguration("ros2_control_file"),
                 }.items(),
             )
         ],
@@ -101,6 +134,7 @@ def generate_launch_description():
             urdf_path_arg,
             base_path_arg,
             use_mock_hardware_arg,
+            ros2_control_file_arg,
             supervisor_launch,
         ]
     )

--- a/launch/gazebo.launch.py
+++ b/launch/gazebo.launch.py
@@ -25,6 +25,7 @@ import os
 from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
+import yaml
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
@@ -51,17 +52,50 @@ def _gz_ros2_control_plugin_path():
         return "/opt/ros/humble/lib"
 
 
-def _default_controllers_yaml(pkg_share: str) -> str:
-    cwd_candidate = Path.cwd() / "src" / "thais_urdf" / "config" / "controllers.yaml"
+_DEFAULT_GENERATED_FILES = {
+    "ros2_control_xacro": "inmoov_ros2_control.xacro",
+    "controllers_yaml": "controllers.yaml",
+}
+
+
+def _active_generated_files(pkg_share: str) -> dict[str, str]:
+    """Generated-artifact filenames from the active preset (defaults if unreadable)."""
+    candidates = [
+        Path.cwd() / "src" / "thais_urdf" / "config" / "hardware" / "active.yaml",
+        Path(pkg_share) / "config" / "hardware" / "active.yaml",
+    ]
+    out = dict(_DEFAULT_GENERATED_FILES)
+    for active in candidates:
+        if not active.is_file():
+            continue
+        try:
+            data = yaml.safe_load(active.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError):
+            return out
+        section = data.get("generated_files") if isinstance(data, dict) else None
+        if isinstance(section, dict):
+            for key in out:
+                value = section.get(key)
+                if isinstance(value, str) and value.strip() and "/" not in value:
+                    out[key] = value.strip()
+        return out
+    return out
+
+
+def _default_controllers_yaml(pkg_share: str, controllers_basename: str) -> str:
+    cwd_candidate = (
+        Path.cwd() / "src" / "thais_urdf" / "config" / controllers_basename
+    )
     if cwd_candidate.is_file():
         return str(cwd_candidate.resolve())
-    return os.path.join(pkg_share, "config", "controllers.yaml")
+    return os.path.join(pkg_share, "config", controllers_basename)
 
 
 def generate_launch_description():
     pkg_share = get_package_share_directory("thais_urdf")
     default_base = os.path.join(pkg_share, "description")
-    default_controllers = _default_controllers_yaml(pkg_share)
+    generated = _active_generated_files(pkg_share)
+    default_controllers = _default_controllers_yaml(pkg_share, generated["controllers_yaml"])
 
     base_path_arg = DeclareLaunchArgument(
         "base_path",
@@ -77,6 +111,11 @@ def generate_launch_description():
         "urdf_path",
         default_value=os.path.join(default_base, "urdf", "inmoov.urdf.xacro"),
         description="Top-level robot xacro",
+    )
+    ros2_control_file_arg = DeclareLaunchArgument(
+        "ros2_control_file",
+        default_value=generated["ros2_control_xacro"],
+        description="Generated ros2_control xacro basename (generated_files in active.yaml)",
     )
     headless_arg = DeclareLaunchArgument(
         "headless",
@@ -187,6 +226,7 @@ def generate_launch_description():
                 "use_gazebo_sim": True,
                 "gazebo_only": True,
                 "autostart": False,
+                "ros2_control_file": LaunchConfiguration("ros2_control_file"),
             }
         ],
     )
@@ -196,6 +236,7 @@ def generate_launch_description():
             base_path_arg,
             controllers_yaml_arg,
             urdf_path_arg,
+            ros2_control_file_arg,
             headless_arg,
             SetEnvironmentVariable(name="GZ_SIM_RESOURCE_PATH", value=mesh_dae),
             SetEnvironmentVariable(


### PR DESCRIPTION
**Summary**

- Regenerated `description/ros2_control/inmoov_ros2_control.xacro` and `config/controllers.yaml` with the new template (real + mock both bound to `lucy_ros2_control/LucySystemHardware`; mock toggles `publish_actuators=false`).
- Refreshed `config/hardware/active.yaml` + `active_meta.yaml` to match the live calibrated mapping; added `config/hardware/configs/SIM_ONLY.yaml` and snapshot backups under `config/hardware/backups/`.
- Updated `launch/control.launch.py` description text and aligned `README.md`, `docs/DEVELOPER.md`, `docs/hardware_mapping.md` so the mock path no longer references `mock_components/GenericSystem`. Added a clear note that stock `gz_ros2_control` does not apply ros2_control `<command_interface min/max>` clamping.